### PR TITLE
Error wrapping specifier for string interpolation

### DIFF
--- a/src/repository/literals.ts
+++ b/src/repository/literals.ts
@@ -118,7 +118,7 @@ export const escapes: TMGrammarScope = {
 export const interpolation: TMGrammarScope = {
 	patterns: [
 		{
-			match: /%([.+#0-9]*)([vTtbcdoOqxXUbeEfFgGsqp])/,
+			match: /%([.+#0-9]*)([vTtbcdoOqxXUbeEfFgGwsqp])/,
 			captures: {
 				1: { name: 'constant.numeric.template-quantifier.go' },
 				2: { name: 'variable.other.go' },
@@ -126,7 +126,7 @@ export const interpolation: TMGrammarScope = {
 			name: 'meta.interpolation.go',
 		},
 		{
-			match: /%(\[)([#0-9]+)(\])([vTtbcdoOqxXUbeEfFgGsqp])/,
+			match: /%(\[)([#0-9]+)(\])([vTtbcdoOqxXUbeEfFgGwsqp])/,
 			captures: {
 				1: { name: 'punctuation.bracket.go' },
 				2: { name: 'constant.numeric.template-quantifier.go' },


### PR DESCRIPTION
Added `w` specifier, which indicates error wrapping introduced at Go 1.13.

```go
parentErr := errors.New("something went wrong")
childErr := fmt.Errorf("from parent: %w", parentErr)
```

https://go.dev/blog/go1.13-errors